### PR TITLE
Add colour scale legend

### DIFF
--- a/public/dengue/may24/resources/config.json
+++ b/public/dengue/may24/resources/config.json
@@ -13,12 +13,16 @@
         "FOI": {
             "colourScale": {
                 "name": "interpolateRdYlBu"
-            }
+            },
+            "humanReadableName": "Force of infection",
+            "unit": ""
         },
         "serop9": {
             "colourScale": {
                 "name": "interpolateGreens"
-            }
+            },
+            "humanReadableName": "Seroprevalence at 9 years of age",
+            "unit": "%"
         }
     }
 }

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -8,6 +8,7 @@ export {}
 declare module 'vue' {
   export interface GlobalComponents {
     Choropleth: typeof import('./components/Choropleth.vue')['default']
+    Legend: typeof import('./components/Legend.vue')['default']
     RouterLink: typeof import('vue-router')['RouterLink']
     RouterView: typeof import('vue-router')['RouterView']
   }

--- a/src/components/Choropleth.vue
+++ b/src/components/Choropleth.vue
@@ -14,8 +14,10 @@
                         return { ...style, fillColor: f.colour, color: borderColor(f.colour) };
                     }
                 "
-            >
-            </LGeoJson>
+            ></LGeoJson>
+            <LControl position="bottomright">
+                <Legend :numberOfSteps="6" />
+            </LControl>
         </LMap>
         <div style="visibility: hidden" class="choropleth-data-summary" v-bind="dataSummary"></div>
     </div>
@@ -24,7 +26,7 @@
 import { ref, computed, watch, Ref } from "vue";
 import { storeToRefs } from "pinia";
 import { LatLngBounds, Layer } from "leaflet";
-import { LGeoJson, LMap, LTileLayer } from "@vue-leaflet/vue-leaflet";
+import { LControl, LGeoJson, LMap, LTileLayer } from "@vue-leaflet/vue-leaflet";
 import { Feature } from "geojson";
 import { useRouter } from "vue-router";
 import Color from "color";

--- a/src/components/Legend.vue
+++ b/src/components/Legend.vue
@@ -1,0 +1,97 @@
+<template>
+    <div class="legend-container">
+        <div class="legend-element map-control p-3">
+            <div class="legend" v-for="(level, index) in scaleLevels" v-bind:key="index">
+                <i v-bind:style="level.style"></i>
+                <span class="level">{{ level.label }}</span>
+                <span class="hidden" style="display: none">{{ level.style }}</span>
+                <br />
+            </div>
+        </div>
+    </div>
+</template>
+
+<script setup lang="ts">
+import { storeToRefs } from "pinia";
+import { useAppStore } from "../stores/appStore";
+import { useColourScale } from "../composables/useColourScale";
+
+const { appConfig, selectedIndicators, selectedIndicator } = storeToRefs(useAppStore());
+
+const { colourScales, indicatorExtremes } = useColourScale(selectedIndicators);
+
+const props = defineProps({
+    numberOfSteps: {
+        type: Number,
+        default: 6,
+        validator: (value: number) => value >= 2
+    }
+});
+
+const colourFunction = computed(() => {
+    return colourScales.value[selectedIndicator.value];
+});
+
+const indicatorUnit = computed(() => {
+    return appConfig.value.indicators[selectedIndicator.value].unit;
+});
+
+const indicatorMin = computed(() => {
+    return indicatorExtremes.value[selectedIndicator.value].min;
+});
+
+const indicatorMax = computed(() => {
+    return indicatorExtremes.value[selectedIndicator.value].max;
+});
+
+const indicatorHasSomeVariance = computed(() => {
+    return indicatorMax.value !== indicatorMin.value;
+});
+
+const roundToSensiblePrecision = (value: number, stepSize: number) => {
+    const stepLeadingZeroes = stepSize.toPrecision(1).includes(".") ? stepSize.toPrecision(1).split(".")[1].length : 0;
+    const roundingNum = 10 ** stepLeadingZeroes;
+    return Math.round(value * roundingNum) / roundingNum;
+};
+
+const stepStyle = (val: number) => {
+    const valAsProportion = indicatorHasSomeVariance.value
+        ? (val - indicatorMin.value) / (indicatorMax.value - indicatorMin.value)
+        : 0;
+    return { background: colourFunction.value(valAsProportion) };
+};
+
+const scaleLevels = computed(() => {
+    if (!(selectedIndicator.value in indicatorExtremes.value)) return [];
+    const stepSize = (indicatorMax.value - indicatorMin.value) / (props.numberOfSteps - 1);
+    return Array.from({ length: indicatorHasSomeVariance.value ? props.numberOfSteps : 1 }, (_, index) => {
+        const stepValue = indicatorMin.value + index * stepSize;
+        return {
+            label: roundToSensiblePrecision(stepValue, stepSize) + indicatorUnit.value,
+            style: stepStyle(stepValue)
+        };
+    }).reverse();
+});
+</script>
+
+<style>
+.legend-container {
+    display: table-cell;
+    position: absolute;
+    left: -4rem;
+    bottom: 2.5rem;
+}
+.legend-element {
+    vertical-align: bottom;
+    display: inline-block;
+}
+.legend {
+    height: 1.125rem;
+}
+.legend i {
+    width: 1.125rem;
+    height: 1.125rem;
+    float: left;
+    margin-right: 0.5rem;
+}
+</style>

--- a/src/components/Legend.vue
+++ b/src/components/Legend.vue
@@ -1,10 +1,9 @@
 <template>
     <div class="legend-container">
-        <div class="legend-element map-control p-3">
-            <div class="legend" v-for="(level, index) in scaleLevels" v-bind:key="index">
+        <div class="legend-element map-control">
+            <div class="legend-item" v-for="(level, index) in scaleLevels" v-bind:key="index" data-testid="legendItem">
                 <i v-bind:style="level.style"></i>
                 <span class="level">{{ level.label }}</span>
-                <span class="hidden" style="display: none">{{ level.style }}</span>
                 <br />
             </div>
         </div>
@@ -33,7 +32,9 @@ const colourFunction = computed(() => {
 });
 
 const indicatorUnit = computed(() => {
-    return appConfig.value.indicators[selectedIndicator.value].unit;
+    const { unit } = appConfig.value.indicators[selectedIndicator.value];
+    if (!unit) return "";
+    return unit === "%" ? unit : ` ${unit}`;
 });
 
 const indicatorMin = computed(() => {
@@ -85,13 +86,14 @@ const scaleLevels = computed(() => {
     vertical-align: bottom;
     display: inline-block;
 }
-.legend {
+.legend-item {
     height: 1.125rem;
-}
-.legend i {
-    width: 1.125rem;
-    height: 1.125rem;
-    float: left;
-    margin-right: 0.5rem;
+
+    i {
+        width: 1.125rem;
+        height: 1.125rem;
+        float: left;
+        margin-right: 0.5rem;
+    }
 }
 </style>

--- a/src/composables/useColourScale.ts
+++ b/src/composables/useColourScale.ts
@@ -81,6 +81,7 @@ export const useColourScale = (selectedIndicators: Ref<Dict<FeatureIndicatorValu
 
     return {
         colourScales,
-        getColour
+        getColour,
+        indicatorExtremes
     };
 };

--- a/src/types/resourceTypes.ts
+++ b/src/types/resourceTypes.ts
@@ -5,6 +5,8 @@ export interface IndicatorConfig {
     colourScale: {
         name: string;
     };
+    unit: string;
+    humanReadableName: string;
 }
 
 export interface AppConfig {

--- a/tests/unit/components/legend.spec.ts
+++ b/tests/unit/components/legend.spec.ts
@@ -1,0 +1,199 @@
+import { render, screen } from "@testing-library/vue";
+import { describe, expect, test } from "vitest";
+import { mockPinia } from "../mocks/mockPinia";
+import Legend from "../../../src/components/Legend.vue";
+import { MOCK_APP_CONFIG } from "../mocks/mockObjects";
+
+const appConfig = {
+    ...MOCK_APP_CONFIG,
+    indicators: {
+        indicatorThatHasSmallNumbers: {
+            colourScale: { name: "interpolateReds" },
+            humanReadableName: "Widgets per 100,000 capita",
+            unit: "widgets"
+        },
+        indicatorMeasuredInPercent: {
+            colourScale: { name: "interpolateBlues" },
+            humanReadableName: "Comorbidity with diabetes",
+            unit: "%"
+        }
+    }
+};
+const admin1Indicators = {
+    TZA: {
+        Region1: {
+            indicatorThatHasSmallNumbers: { mean: 0.0005123456789, sd: 1 },
+            indicatorMeasuredInPercent: { mean: 0.1123456789, sd: 1 }
+        },
+        Region2: {
+            indicatorThatHasSmallNumbers: { mean: 0.0002123456789, sd: 1 },
+            indicatorMeasuredInPercent: { mean: 0.3123456789, sd: 1 }
+        }
+    }
+};
+const admin2Indicators = {
+    TZA: {
+        "Region1-a": {
+            indicatorThatHasSmallNumbers: { mean: 0.0003123456789, sd: 1 },
+            indicatorMeasuredInPercent: { mean: 0.4123456789, sd: 1 }
+        },
+        "Region1-b": {
+            indicatorThatHasSmallNumbers: { mean: 0.0003223456789, sd: 1 },
+            indicatorMeasuredInPercent: { mean: 0.4223456789, sd: 1 }
+        },
+        "Region2-a": {
+            indicatorThatHasSmallNumbers: { mean: 0.0003987654321, sd: 1 },
+            indicatorMeasuredInPercent: { mean: 0.4123456789, sd: 1 }
+        },
+        "Region2-b": {
+            indicatorThatHasSmallNumbers: { mean: 0.0003, sd: 1 },
+            indicatorMeasuredInPercent: { mean: 0.4223456789, sd: 1 }
+        }
+    }
+};
+
+const defaultNumberOfSteps = 6;
+
+let store;
+const renderComponent = () => {
+    return render(Legend, {
+        global: {
+            plugins: [store]
+        }
+    });
+};
+
+describe("Legend", () => {
+    describe("when a number of steps is specified", () => {
+        test("renders the specified no. of steps", () => {
+            const numberOfSteps = 10;
+            render(Legend, { global: { plugins: [mockPinia()] }, props: { numberOfSteps } });
+            const legendItems = screen.getAllByTestId("legendItem");
+            expect(legendItems).toHaveLength(numberOfSteps);
+        });
+    });
+
+    describe("when a country has been selected", () => {
+        const selectedCountryId = "TZA";
+
+        describe("when the selected indicator is indicatorThatHasSmallNumbers", () => {
+            beforeAll(() => {
+                store = mockPinia({
+                    admin1Indicators,
+                    admin2Indicators,
+                    appConfig,
+                    selectedCountryId,
+                    selectedIndicator: "indicatorThatHasSmallNumbers"
+                });
+            });
+
+            test("renders default no. of steps, and rounds numbers to a sensible precision", async () => {
+                renderComponent();
+                const legendItems = screen.getAllByTestId("legendItem");
+                expect(legendItems).toHaveLength(defaultNumberOfSteps);
+                const displayedValues = legendItems.map((item) => parseFloat(item.textContent));
+                // Ensure displayed values are in descending order
+                expect(displayedValues).toEqual(displayedValues.sort().reverse());
+                expect(displayedValues[0]).toEqual(0.0004);
+                expect(displayedValues[1]).toEqual(0.00038);
+                expect(displayedValues[2]).toEqual(0.00036);
+                expect(displayedValues[3]).toEqual(0.00034);
+                expect(displayedValues[4]).toEqual(0.00032);
+                expect(displayedValues[5]).toEqual(0.0003);
+                // Test units are displayed
+                expect(legendItems[0].textContent).toEqual("0.0004 widgets");
+            });
+        });
+
+        describe("when the selected indicator is indicatorMeasuredInPercent", () => {
+            beforeAll(() => {
+                store = mockPinia({
+                    admin1Indicators,
+                    admin2Indicators,
+                    appConfig,
+                    selectedCountryId,
+                    selectedIndicator: "indicatorMeasuredInPercent"
+                });
+            });
+
+            test("renders default no. of steps, and rounds numbers to a sensible precision", async () => {
+                renderComponent();
+                const legendItems = screen.getAllByTestId("legendItem");
+                expect(legendItems).toHaveLength(defaultNumberOfSteps);
+                const displayedValues = legendItems.map((item) => parseFloat(item.textContent));
+                // Ensure displayed values are in descending order
+                expect(displayedValues).toEqual(displayedValues.sort().reverse());
+                expect(displayedValues[0]).toEqual(0.422);
+                expect(displayedValues[1]).toEqual(0.42);
+                expect(displayedValues[2]).toEqual(0.418);
+                expect(displayedValues[3]).toEqual(0.416);
+                expect(displayedValues[4]).toEqual(0.414);
+                expect(displayedValues[5]).toEqual(0.412);
+                // Test units are displayed
+                expect(legendItems[0].textContent).toEqual("0.422%");
+            });
+        });
+    });
+
+    describe("when a country has not been selected", () => {
+        const selectedCountryId = null;
+
+        describe("when the selected indicator is indicatorThatHasSmallNumbers", () => {
+            beforeAll(() => {
+                store = mockPinia({
+                    admin1Indicators,
+                    admin2Indicators,
+                    appConfig,
+                    selectedCountryId,
+                    selectedIndicator: "indicatorThatHasSmallNumbers"
+                });
+            });
+
+            test("renders default no. of steps, and rounds numbers to a sensible precision", async () => {
+                renderComponent();
+                const legendItems = screen.getAllByTestId("legendItem");
+                expect(legendItems).toHaveLength(defaultNumberOfSteps);
+                const displayedValues = legendItems.map((item) => parseFloat(item.textContent));
+                // Ensure displayed values are in descending order
+                expect(displayedValues).toEqual(displayedValues.sort().reverse());
+                expect(displayedValues[0]).toEqual(0.00051);
+                expect(displayedValues[1]).toEqual(0.00045);
+                expect(displayedValues[2]).toEqual(0.00039);
+                expect(displayedValues[3]).toEqual(0.00033);
+                expect(displayedValues[4]).toEqual(0.00027);
+                expect(displayedValues[5]).toEqual(0.00021);
+                // Test units are displayed
+                expect(legendItems[0].textContent).toEqual("0.00051 widgets");
+            });
+        });
+
+        describe("when the selected indicator is indicatorMeasuredInPercent", () => {
+            beforeAll(() => {
+                store = mockPinia({
+                    admin1Indicators,
+                    admin2Indicators,
+                    appConfig,
+                    selectedCountryId,
+                    selectedIndicator: "indicatorMeasuredInPercent"
+                });
+            });
+
+            test("renders default no. of steps, and rounds numbers to a sensible precision", async () => {
+                renderComponent();
+                const legendItems = screen.getAllByTestId("legendItem");
+                expect(legendItems).toHaveLength(defaultNumberOfSteps);
+                const displayedValues = legendItems.map((item) => parseFloat(item.textContent));
+                // Ensure displayed values are in descending order
+                expect(displayedValues).toEqual(displayedValues.sort().reverse());
+                expect(displayedValues[0]).toEqual(0.31);
+                expect(displayedValues[1]).toEqual(0.27);
+                expect(displayedValues[2]).toEqual(0.23);
+                expect(displayedValues[3]).toEqual(0.19);
+                expect(displayedValues[4]).toEqual(0.15);
+                expect(displayedValues[5]).toEqual(0.11);
+                // Test units are displayed
+                expect(legendItems[0].textContent).toEqual("0.31%");
+            });
+        });
+    });
+});

--- a/tests/unit/mocks/mockObjects.ts
+++ b/tests/unit/mocks/mockObjects.ts
@@ -11,10 +11,14 @@ export const MOCK_APP_CONFIG = {
     },
     indicators: {
         FOI: {
-            colourScale: { name: "interpolateReds" }
+            colourScale: { name: "interpolateReds" },
+            humanReadableName: "Force of infection",
+            unit: ""
         },
         serop9: {
-            colourScale: { name: "interpolateBlues" }
+            colourScale: { name: "interpolateBlues" },
+            humanReadableName: "Seroprevalence at 9 years of age",
+            unit: "%"
         }
     }
 };

--- a/tests/unit/setupTests.ts
+++ b/tests/unit/setupTests.ts
@@ -8,8 +8,9 @@ beforeAll(() => {
     vi.mock("@vue-leaflet/vue-leaflet", () => {
         return {
             LMap: defineComponent({ template: "<l-map-stub><slot></slot></l-map-stub>" }),
-            LTileLayer: defineComponent({ template: "<l-tile-layer></l-tile-layer>" }),
-            LGeoJson: defineComponent({ template: "<l-geo-json></l-geo-json>" })
+            LTileLayer: defineComponent({ template: "<l-tile-layer-stub></l-tile-layer-stub>" }),
+            LGeoJson: defineComponent({ template: "<l-geo-json-stub></l-geo-json-stub>" }),
+            LControl: defineComponent({ template: "<l-control-stub></l-control-stub>" })
         };
     });
 });


### PR DESCRIPTION
https://mrc-ide.myjetbrains.com/youtrack/issue/mrc-5257

Code is based on the MapLegend component from [HINT](https://github.com/mrc-ide/hint).

Like https://github.com/mrc-ide/arbomap/pull/7/ this introduces units and human-readable names for indicators into the config.json.

