### PR TITLE
Mrc 5169 Lock on to country bounds and set min zoom + remove empty scrollbar

### DIFF
--- a/.github/workflows/deploy-to-ghp.yml
+++ b/.github/workflows/deploy-to-ghp.yml
@@ -4,7 +4,7 @@ name: Deploy static content to Pages
 on:
   # Runs on pushes targeting the default branch
   push:
-    branches: ['main', 'mrc-5203']
+    branches: ['main', 'mrc-5169']
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/src/components/Choropleth.vue
+++ b/src/components/Choropleth.vue
@@ -4,7 +4,7 @@
             class="map"
             ref="map"
             style="height: calc(100vh - 48px); width: 100%"
-            @update:bounds="lockBounds"
+            @update:bounds="mapBoundsUpdated"
             @ready="() => updateMap(selectedFeatures)"
             :max-bounds-viscosity="1"
         >
@@ -145,7 +145,7 @@ const style = (f: Feature) => {
 
 const getLeafletMap = () => map.value?.leafletObject;
 
-const lockBounds = async () => {
+const mapBoundsUpdated = async () => {
     const leafletMap = getLeafletMap();
     if (!leafletMap) return;
 
@@ -158,17 +158,17 @@ const lockBounds = async () => {
     waitingForMapBounds.value = false;
 };
 
-const getBoundsForCountry = (countryId?: string) => {
+const getRegionBounds = (countryId?: string) => {
     if (Object.keys(countryBoundingBoxes.value).length === 0) return null;
     const [west, east, south, north] = countryBoundingBoxes.value[countryId || "GLOBAL"];
     return new LatLngBounds([south, west], [north, east]);
 };
 
 const updateBounds = async () => {
-    const leafletMap = toRaw(map.value)?.leafletObject;
+    const leafletMap = getLeafletMap();
     if (!leafletMap) return;
 
-    const countryBounds = getBoundsForCountry(selectedCountryId.value);
+    const countryBounds = getRegionBounds(selectedCountryId.value);
     if (!countryBounds) return;
 
     bounds.value = countryBounds;
@@ -176,13 +176,13 @@ const updateBounds = async () => {
 };
 
 const resetMaxBoundsAndZoom = () => {
-    const leafletMap = toRaw(map.value)?.leafletObject;
+    const leafletMap = getLeafletMap();
     if (!leafletMap) return;
 
-    const globalBounds = getBoundsForCountry();
+    const globalBounds = getRegionBounds();
     if (!globalBounds) return;
 
-    leafletMap.setMinZoom(2.5);
+    leafletMap.setMinZoom(3);
     leafletMap.setMaxBounds(globalBounds);
 };
 

--- a/src/components/Choropleth.vue
+++ b/src/components/Choropleth.vue
@@ -220,5 +220,7 @@ watch(selectedFeatures, (newFeatures) => {
 
 watch(selectedIndicator, () => updateMap());
 
-watch(selectedCountryId, () => (isNewSelectedCountry.value = true));
+watch(selectedCountryId, () => {
+    isNewSelectedCountry.value = true;
+});
 </script>

--- a/src/components/Choropleth.vue
+++ b/src/components/Choropleth.vue
@@ -144,9 +144,8 @@ const style = (f: Feature) => {
 };
 
 const lockBounds = async () => {
-    const rawMap = toRaw(map.value);
-    if (!rawMap) return;
-    const leafletMap = rawMap.leafletObject;
+    const leafletMap = toRaw(map.value)?.leafletObject;
+    if (!leafletMap) return;
 
     if (isNewSelectedCountry.value && selectedCountryId.value) {
         leafletMap.setMaxBounds(leafletMap.getBounds());
@@ -163,9 +162,8 @@ const getBoundsForCountry = (countryId?: string) => {
 };
 
 const updateBounds = async () => {
-    const rawMap = toRaw(map.value);
-    if (!rawMap || Object.keys(countryBoundingBoxes.value).length === 0) return;
-    const leafletMap = rawMap.leafletObject;
+    const leafletMap = toRaw(map.value)?.leafletObject;
+    if (!leafletMap || Object.keys(countryBoundingBoxes.value).length === 0) return;
 
     // need to reset min zoom and max bounds so we can zoom out to world
     const globalBounds = getBoundsForCountry();
@@ -177,9 +175,8 @@ const updateBounds = async () => {
 };
 
 const updateMap = async (newFeatures: Feature[]) => {
-    const rawMap = toRaw(map.value);
-    if (!rawMap) return;
-    const leafletMap = rawMap.leafletObject;
+    const leafletMap = toRaw(map.value)?.leafletObject;
+    if (!leafletMap) return;
 
     // remove layers from map
     geoJsonLayer.value.remove();

--- a/src/components/Choropleth.vue
+++ b/src/components/Choropleth.vue
@@ -95,7 +95,8 @@ const dataSummary = computed(() => ({
     "selected-country-feature-count": selectedFeatures.value.filter(
         (f) => f.properties![featureProperties.country] === selectedCountryId.value
     ).length,
-    bounds: `S: ${bounds.value?.getSouth()} W: ${bounds.value?.getWest()} N: ${bounds.value?.getNorth()}` +
+    bounds:
+        `S: ${bounds.value?.getSouth()} W: ${bounds.value?.getWest()} N: ${bounds.value?.getNorth()}` +
         `E: ${bounds.value?.getEast()}`
 }));
 
@@ -206,5 +207,7 @@ const updateMap = async (newFeatures: Feature[]) => {
 };
 
 watch([selectedFeatures, selectedIndicator], (newVal) => updateMap(newVal[0]));
-watch(selectedCountryId, () => isNewSelectedCountry.value = true);
+watch(selectedCountryId, () => {
+    isNewSelectedCountry.value = true;
+});
 </script>

--- a/src/styles/settings.scss
+++ b/src/styles/settings.scss
@@ -9,6 +9,10 @@
 //   $color-pack: false
 // );
 
+html {
+  overflow-y: auto;
+}
+
 .geojson {
   stroke-width: 1;
   fill-opacity: 0.7;

--- a/tests/e2e/index.spec.ts
+++ b/tests/e2e/index.spec.ts
@@ -115,16 +115,16 @@ test.describe("Index page", () => {
         await firstRegion.click();
         await expect(await page.locator("div.spinner")).toHaveCount(0);
         // zoom out is disabled in leaflet
-        await expect(await page.locator(".leaflet-control-zoom-out .leaflet-disabled")).toHaveCount(1);
+        await expect(await page.locator(".leaflet-control-zoom-out.leaflet-disabled")).toHaveCount(1);
     });
 
     test("user can't zoom out after selecting country and changing indicator", async ({ page }) => {
         const firstRegion = await getNthRegion(page, 1);
         await firstRegion.click();
         await expect(await page.locator("div.spinner")).toHaveCount(0);
-        await expect(await page.locator(".leaflet-control-zoom-out .leaflet-disabled")).toHaveCount(1);
+        await expect(await page.locator(".leaflet-control-zoom-out.leaflet-disabled")).toHaveCount(1);
         await page.getByText("SEROP9").click();
         await page.waitForURL(/dengue\/may24\/serop9/);
-        await expect(await page.locator(".leaflet-control-zoom-out .leaflet-disabled")).toHaveCount(1);
+        await expect(await page.locator(".leaflet-control-zoom-out.leaflet-disabled")).toHaveCount(1);
     });
 });

--- a/tests/e2e/index.spec.ts
+++ b/tests/e2e/index.spec.ts
@@ -117,4 +117,14 @@ test.describe("Index page", () => {
         // zoom out is disabled in leaflet
         await expect(await page.locator(".leaflet-control-zoom-out .leaflet-disabled")).toHaveCount(1);
     });
+
+    test("user can't zoom out after selecting country and changing indicator", async ({ page }) => {
+        const firstRegion = await getNthRegion(page, 1);
+        await firstRegion.click();
+        await expect(await page.locator("div.spinner")).toHaveCount(0);
+        await expect(await page.locator(".leaflet-control-zoom-out .leaflet-disabled")).toHaveCount(1);
+        await page.getByText("SEROP9").click();
+        await page.waitForURL(/dengue\/may24\/serop9/);
+        await expect(await page.locator(".leaflet-control-zoom-out .leaflet-disabled")).toHaveCount(1);
+    });
 });

--- a/tests/e2e/index.spec.ts
+++ b/tests/e2e/index.spec.ts
@@ -123,7 +123,7 @@ test.describe("Index page", () => {
         await firstRegion.click();
         await expect(await page.locator("div.spinner")).toHaveCount(0);
         await expect(await page.locator(".leaflet-control-zoom-out.leaflet-disabled")).toHaveCount(1);
-        await page.getByRole('link', { name: 'serop9' }).click();
+        await page.getByRole("link", { name: "serop9" }).click();
         await page.waitForURL(/dengue\/may24\/serop9/);
         await expect(await page.locator(".leaflet-control-zoom-out.leaflet-disabled")).toHaveCount(1);
     });

--- a/tests/e2e/index.spec.ts
+++ b/tests/e2e/index.spec.ts
@@ -109,4 +109,12 @@ test.describe("Index page", () => {
         await expect(await allRegions).toHaveCount(1833);
         await expect(page).toHaveURL("/dengue/may24/serop9");
     });
+
+    test("after selecting country, user can't zoom out", async ({ page }) => {
+        const firstRegion = await getNthRegion(page, 1);
+        await firstRegion.click();
+        await expect(await page.locator("div.spinner")).toHaveCount(0);
+        // zoom out is disabled in leaflet
+        await expect(await page.locator(".leaflet-control-zoom-out .leaflet-disabled")).toHaveCount(1);
+    });
 });

--- a/tests/e2e/index.spec.ts
+++ b/tests/e2e/index.spec.ts
@@ -123,7 +123,7 @@ test.describe("Index page", () => {
         await firstRegion.click();
         await expect(await page.locator("div.spinner")).toHaveCount(0);
         await expect(await page.locator(".leaflet-control-zoom-out.leaflet-disabled")).toHaveCount(1);
-        await page.getByText("SEROP9").click();
+        await page.getByRole('link', { name: 'serop9' }).click();
         await page.waitForURL(/dengue\/may24\/serop9/);
         await expect(await page.locator(".leaflet-control-zoom-out.leaflet-disabled")).toHaveCount(1);
     });


### PR DESCRIPTION
This PR should lock the bounds and minimum zoom of the leaflet map view. There was also an annoying empty scrollbar on the side of the map. Just got rid of that with some css :)

Main changes:
* flag for when country is selected, this is to stop us from locking the bounds every time someone changes anything, otherwise the user would only be able to zoom in and never zoom out
* I reset the `maxBounds` and `minZoom` of the leaflet map every time the features change to make sure we can actually zoom out all the way when we go to global view

Note: you may be thinking we have the bounding boxes, why not just set the bounds with that, the bounding boxes are too tight and leaflet already does its own calculation about fitting the bounding box with the maximum zoom out possible, so we let it do its thing, once it is done we just use those bounds and lock them in

Deployed to ghp: https://mrc-ide.github.io/arbomap

The tooltips will stay when you click and drag on locked boundaries, this will be fixed in the next PR!