### PR TITLE
Mrc 5200 Add admin level toggle

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -30,7 +30,8 @@ export default defineConfig({
         /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
         trace: "on-first-retry",
 
-        headless: true
+        headless: true,
+        screenshot: "only-on-failure"
     },
 
     /* Configure projects for major browsers */

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -7,6 +7,7 @@ export {}
 
 declare module 'vue' {
   export interface GlobalComponents {
+    AdminLevelToggle: typeof import('./components/AdminLevelToggle.vue')['default']
     Choropleth: typeof import('./components/Choropleth.vue')['default']
     ColourScaleIcon: typeof import('./components/indicatorMenu/ColourScaleIcon.vue')['default']
     IndicatorMenu: typeof import('./components/indicatorMenu/IndicatorMenu.vue')['default']

--- a/src/components/AdminLevelToggle.vue
+++ b/src/components/AdminLevelToggle.vue
@@ -1,0 +1,22 @@
+<template>
+    <v-btn-toggle id="admin-toggle" :model-value="mapSettings.adminLevel" @update:model-value="emit('change-admin-level', $event)" mandatory :max="1" :density="'compact'" theme="dark">
+        <v-btn :value="1" :ripple="false" selected-class="selected-button">Admin 1</v-btn>
+        <v-btn :value="2" :ripple="false" :disabled="admin2DataMissing" selected-class="selected-button">Admin 2</v-btn>
+    </v-btn-toggle>
+</template>
+
+<script setup lang="ts">
+import { storeToRefs } from "pinia";
+import { useAppStore } from "../stores/appStore";
+
+const { mapSettings, appConfig } = storeToRefs(useAppStore());
+
+const admin2DataMissing = computed(() => appConfig.value.countriesWithoutAdmin2.includes(mapSettings.value.country));
+
+const emit = defineEmits(["change-admin-level"]);
+</script>
+<style scoped>
+.selected-button {
+    font-weight: bolder;
+}
+</style>

--- a/src/components/AdminLevelToggle.vue
+++ b/src/components/AdminLevelToggle.vue
@@ -1,5 +1,13 @@
 <template>
-    <v-btn-toggle id="admin-toggle" :model-value="mapSettings.adminLevel" @update:model-value="emit('change-admin-level', $event)" mandatory :max="1" :density="'compact'" theme="dark">
+    <v-btn-toggle
+        id="admin-toggle"
+        :model-value="mapSettings.adminLevel"
+        @update:model-value="emit('change-admin-level', $event)"
+        mandatory
+        :max="1"
+        :density="'compact'"
+        theme="dark"
+    >
         <v-btn :value="1" :ripple="false" selected-class="selected-button">Admin 1</v-btn>
         <v-btn :value="2" :ripple="false" :disabled="admin2DataMissing" selected-class="selected-button">Admin 2</v-btn>
     </v-btn-toggle>

--- a/src/components/Choropleth.vue
+++ b/src/components/Choropleth.vue
@@ -15,6 +15,9 @@
             <LControl position="topleft">
                 <ResetMapButton :selected-indicator="mapSettings.indicator" @reset-view="updateRegionBounds" />
             </LControl>
+            <LControl position="topright" v-if="mapSettings.country">
+                <AdminLevelToggle @change-admin-level="handleChangeAdminLevel" />
+            </LControl>
         </LMap>
         <div style="visibility: hidden" class="choropleth-data-summary" v-bind="dataSummary"></div>
     </div>
@@ -31,10 +34,11 @@ import { useLeaflet } from "../composables/useLeaflet";
 import "leaflet/dist/leaflet.css";
 import { useTooltips } from "../composables/useTooltips";
 import { APP_BASE_ROUTE } from "../router/utils";
-import { debounce } from "../utils";
+import { routerPush, AdminLevel } from "../utils";
 import { backgroundLayer } from "./utils";
 import { useLoadingSpinner } from "../composables/useLoadingSpinner";
 import { useSelectedMapInfo } from "../composables/useSelectedMapInfo";
+import AdminLevelToggle from "./AdminLevelToggle.vue";
 
 const mapLoading = ref(true);
 const router = useRouter();
@@ -61,6 +65,13 @@ const getFeatureName = (feature: Feature) =>
         ? feature.properties[featureProperties.nameAdm2]
         : feature.properties[featureProperties.nameAdm1];
 
+const handleChangeAdminLevel = (level: number) => {
+    mapLoading.value = true;
+    const { indicator, country } = mapSettings.value;
+    const adminLevel = level === 1 ? AdminLevel.ONE : AdminLevel.TWO;
+    routerPush(router, `/${APP_BASE_ROUTE}/${indicator}/${country}/${adminLevel}`);
+};
+
 const style = (f: Feature) => {
     const { country, indicator } = mapSettings.value;
     const isFaded = !!country && !featureInSelectedCountry(f);
@@ -80,7 +91,7 @@ const layerOnEvents = (feature: Feature) => {
             const country = feature.properties[featureProperties.country];
             // select feature's country, or unselect if click on it when already selected
             const countryToSelect = country === mapSettings.value.country ? "" : country;
-            debounce(() => router.push(`/${APP_BASE_ROUTE}/${mapSettings.value.indicator}/${countryToSelect}`))();
+            routerPush(router, `/${APP_BASE_ROUTE}/${mapSettings.value.indicator}/${countryToSelect}`);
         }
     };
 };
@@ -93,9 +104,7 @@ const { map, dataSummary, lockBounds, updateLeafletMap, handleMapBoundsUpdated, 
 useLoadingSpinner(map, mapLoading);
 
 const updateMap = () => {
-    if (mapSettings.value.country) {
-        lockBounds.value = true;
-    }
+    lockBounds.value = !!mapSettings.value.country;
     updateLeafletMap(selectedFeatures.value, mapSettings.value.country);
 };
 

--- a/src/components/ResetMapButton.vue
+++ b/src/components/ResetMapButton.vue
@@ -19,6 +19,7 @@ import { useRouter } from "vue-router";
 import { defineProps, defineEmits } from "vue";
 import { APP_BASE_ROUTE } from "../router/utils";
 import { useAppStore } from "../stores/appStore";
+import { routerPush } from "../utils";
 
 const { mapSettings } = storeToRefs(useAppStore());
 const router = useRouter();
@@ -35,7 +36,7 @@ const emit = defineEmits(["resetView"]);
 const resetView = () => {
     const homePath = `/${APP_BASE_ROUTE}/${props.selectedIndicator}`;
     if (mapSettings.value.country) {
-        router.push(homePath);
+        routerPush(router, homePath);
     } else {
         emit("resetView");
     }

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -101,9 +101,12 @@ const selectDataForRoute = async () => {
     if (country) {
         const admin2DataMissing = appConfig.value.countriesWithoutAdmin2.includes(country);
         if (!adminLevel) {
-            router.replace(`/${pathogen}/${version}/${indicator}/${country}/${admin2DataMissing ? AdminLevel.ONE : AdminLevel.TWO}`);
+            router.replace(
+                `/${pathogen}/${version}/${indicator}/${country}/${admin2DataMissing ? AdminLevel.ONE : AdminLevel.TWO}`
+            );
             return;
-        } else if (adminLevel === AdminLevel.TWO && admin2DataMissing) {
+        }
+        if (adminLevel === AdminLevel.TWO && admin2DataMissing) {
             router.replace(`/${pathogen}/${version}/${indicator}/${country}/${AdminLevel.ONE}`);
             return;
         }

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -17,7 +17,7 @@ import { useRouter } from "vue-router";
 import { useAppStore } from "../stores/appStore";
 import NotFound from "./notFound.vue";
 import { APP_BASE_ROUTE, PATHOGEN, VERSION } from "../router/utils";
-import { mapSettingsAreEqual } from "../utils";
+import { mapSettingsAreEqual, stringAdminLevelToNumeric, AdminLevel } from "../utils";
 import { MapSettings } from "../types/resourceTypes";
 
 const router = useRouter();
@@ -41,6 +41,11 @@ const props = defineProps({
         default: ""
     },
     country: {
+        type: String,
+        required: false,
+        default: ""
+    },
+    adminLevel: {
         type: String,
         required: false,
         default: ""
@@ -71,7 +76,8 @@ const selectDataForRoute = async () => {
         pathogen: [PATHOGEN],
         version: [VERSION],
         indicator: Object.keys(appConfig.value.indicators),
-        country: appConfig.value.countries
+        country: appConfig.value.countries,
+        adminLevel: Object.keys(stringAdminLevelToNumeric)
     };
     const propsWithCorrectCase: Partial<Record<PropName, string>> = {};
     Object.keys(possibleValuesForProps).forEach((prop: PropName) => {
@@ -86,18 +92,29 @@ const selectDataForRoute = async () => {
     unknownProps.value = unknown;
     if (unknownProps.value.length) return;
 
+    const { pathogen, version, indicator, country, adminLevel } = propsWithCorrectCase;
     // we pick dengue, may24 and FOI as defaults for pathogen, version and indicator respectively
-    if (!props.indicator) {
+    if (!indicator) {
         router.replace(`/${APP_BASE_ROUTE}/${possibleValuesForProps.indicator[0]}`);
         return;
     }
+    if (country) {
+        const admin2DataMissing = appConfig.value.countriesWithoutAdmin2.includes(country);
+        if (!adminLevel) {
+            router.replace(`/${pathogen}/${version}/${indicator}/${country}/${admin2DataMissing ? AdminLevel.ONE : AdminLevel.TWO}`);
+            return;
+        } else if (adminLevel === AdminLevel.TWO && admin2DataMissing) {
+            router.replace(`/${pathogen}/${version}/${indicator}/${country}/${AdminLevel.ONE}`);
+            return;
+        }
+    }
 
     const newMapSettings: MapSettings = {
-        pathogen: propsWithCorrectCase.pathogen,
-        version: propsWithCorrectCase.version,
-        indicator: propsWithCorrectCase.indicator,
-        country: propsWithCorrectCase.country,
-        adminLevel: propsWithCorrectCase.country ? 2 : 1
+        pathogen,
+        version,
+        indicator,
+        country,
+        adminLevel: country ? stringAdminLevelToNumeric[adminLevel] : 1
     };
     if (!mapSettingsAreEqual(mapSettings.value, newMapSettings)) {
         await updateMapSettings(newMapSettings);

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -9,7 +9,7 @@ import { PATHOGEN } from "./utils";
 const router = createRouter({
     history: createWebHistory(import.meta.env.BASE_URL),
     routes: [
-        { path: "/:pathogen?/:version?/:indicator?/:country?", component: index, props: true },
+        { path: "/:pathogen?/:version?/:indicator?/:country?/:adminLevel?", component: index, props: true },
         { path: `/${PATHOGEN}/about`, component: about },
         { path: `/${PATHOGEN}/accessibility`, component: accessibility },
         { path: `/${PATHOGEN}/privacy`, component: privacy },

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -48,14 +48,14 @@ export const useAppStore = defineStore("app", {
             // Some countries do not have admin2 regions or data - if one of these is selected, we load
             // a more detailed geojson, and re-use its admin1 indicators as "admin2"
             const admin2DataMissing = state.appConfig.countriesWithoutAdmin2.includes(country);
-            if (level === 2 && admin2DataMissing) {
-                level = 1;
-                state.admin2Indicators[country] = state.admin1Indicators[country];
-            }
-
-            if (level === 2 && !admin2DataMissing) {
-                state.admin2Indicators[country] =
-                    state.admin2Indicators[country] || (await getIndicators(country, level));
+            if (level === 2) {
+                if (admin2DataMissing) {
+                    level = 1;
+                    state.admin2Indicators[country] = state.admin1Indicators[country];
+                } else {
+                    state.admin2Indicators[country] =
+                        state.admin2Indicators[country] || (await getIndicators(country, level));
+                }
             }
 
             state.admin2Geojson[country] = state.admin2Geojson[country] || (await getGeojsonFeatures(country, level));

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,4 @@
+import { Router } from "vue-router";
 import { MapSettings } from "./types/resourceTypes";
 
 export function debounce(fn, wait = 0) {
@@ -16,4 +17,20 @@ export const mapSettingsAreEqual = (mapSettings1: MapSettings, mapSettings2: Map
     if (mapSettings1 === null && !!mapSettings2) return false;
     if (mapSettings2 === null && !!mapSettings1) return false;
     return Object.keys(mapSettings1).every((key: keyof MapSettings) => mapSettings1[key] === mapSettings2[key]);
+};
+
+export enum AdminLevel {
+    ONE = "admin1",
+    TWO = "admin2"
+}
+
+export const stringAdminLevelToNumeric = {
+    [AdminLevel.ONE]: 1,
+    [AdminLevel.TWO]: 2
+};
+
+export const routerDebounce = 75;
+
+export const routerPush = (router: Router, path: string) => {
+    debounce(() => router.push(path), routerDebounce)();
 };

--- a/tests/e2e/index.spec.ts
+++ b/tests/e2e/index.spec.ts
@@ -164,6 +164,10 @@ test.describe("Index page", () => {
     });
 
     test("admin level toggle works", async ({ page }) => {
+        const adminToggle = await page.locator("#admin-toggle");
+
+        await expect(adminToggle).toHaveCount(0);
+
         const allRegions = await page.locator(GEOJSON_SELECTOR);
         const firstRegion = await getNthRegion(page, 1);
         await firstRegion.click();
@@ -171,11 +175,16 @@ test.describe("Index page", () => {
 
         await expect(await allRegions).toHaveCount(1978);
 
-        const adminToggle = await page.locator("#admin-toggle");
         await expect(adminToggle).toHaveCount(1);
         await adminToggle.getByRole("button", { name: "Admin 1" }).click();
         await page.waitForURL(/dengue\/may24\/FOI\/AGO\/admin1/i);
 
         await expect(await allRegions).toHaveCount(1833);
+    });
+
+    test("admin level defaults to 1 for countries with missing admin 2 data", async ({ page }) => {
+        // ATG has missing admin level 2 data
+        page.goto("dengue/may24/FOI/ATG");
+        await page.waitForURL(/dengue\/may24\/FOI\/ATG\/admin1/i);
     });
 });

--- a/tests/e2e/index.spec.ts
+++ b/tests/e2e/index.spec.ts
@@ -163,7 +163,7 @@ test.describe("Index page", () => {
         await expect(await page.locator(".leaflet-control-zoom-out.leaflet-disabled")).toHaveCount(1);
     });
 
-    test("admin toggle works", async ({ page }) => {
+    test("admin level toggle works", async ({ page }) => {
         const allRegions = await page.locator(GEOJSON_SELECTOR);
         const firstRegion = await getNthRegion(page, 1);
         await firstRegion.click();

--- a/tests/e2e/index.spec.ts
+++ b/tests/e2e/index.spec.ts
@@ -162,4 +162,20 @@ test.describe("Index page", () => {
         await page.waitForURL(/dengue\/may24\/serop9/);
         await expect(await page.locator(".leaflet-control-zoom-out.leaflet-disabled")).toHaveCount(1);
     });
+
+    test("admin toggle works", async ({ page }) => {
+        const allRegions = await page.locator(GEOJSON_SELECTOR);
+        const firstRegion = await getNthRegion(page, 1);
+        await firstRegion.click();
+        await page.waitForURL(/dengue\/may24\/FOI\/AGO\/admin2/i);
+
+        await expect(await allRegions).toHaveCount(1978);
+
+        const adminToggle = await page.locator("#admin-toggle");
+        await expect(adminToggle).toHaveCount(1);
+        await adminToggle.getByRole("button", { name: "Admin 1" }).click();
+        await page.waitForURL(/dengue\/may24\/FOI\/AGO\/admin1/i);
+
+        await expect(await allRegions).toHaveCount(1833);
+    });
 });

--- a/tests/e2e/routing.spec.ts
+++ b/tests/e2e/routing.spec.ts
@@ -65,7 +65,7 @@ test.describe("Router", () => {
 
     test("is case-insensitive", async ({ page }) => {
         await page.goto("/DENGUE/May24/SEROP9/tza");
-        await page.waitForURL(/\/DENGUE\/May24\/SEROP9\/tza/);
+        await page.waitForURL(/\/dengue\/may24\/serop9\/TZA/);
         await expect(await page.textContent(".indicator-menu-activator")).toBe("Seroprevalence at 9 years of age");
         const summary = await page.locator(".choropleth-data-summary");
         await expect(await summary).toHaveAttribute("colour-scale", "interpolateGreens");

--- a/tests/unit/components/adminLevelToggle.spec.ts
+++ b/tests/unit/components/adminLevelToggle.spec.ts
@@ -37,7 +37,8 @@ describe("AdminLevelToggle", () => {
     test("admin level 2 is disabled if country missing admin 2 data", async () => {
         const { findAllByRole } = renderComponent(2, true);
         const buttons = await findAllByRole("button");
-        const [, admin2Button] = buttons;
+        const [admin1Button, admin2Button] = buttons;
+        expect(admin1Button).toHaveClass("selected-button");
         expect(admin2Button).toBeDisabled();
     });
 

--- a/tests/unit/components/adminLevelToggle.spec.ts
+++ b/tests/unit/components/adminLevelToggle.spec.ts
@@ -35,7 +35,7 @@ describe("AdminLevelToggle", () => {
     });
 
     test("admin level 2 is disabled if country missing admin 2 data", async () => {
-        const { findAllByRole } = renderComponent(2, true);
+        const { findAllByRole } = renderComponent(1, true);
         const buttons = await findAllByRole("button");
         const [admin1Button, admin2Button] = buttons;
         expect(admin1Button).toHaveClass("selected-button");

--- a/tests/unit/components/adminLevelToggle.spec.ts
+++ b/tests/unit/components/adminLevelToggle.spec.ts
@@ -1,0 +1,51 @@
+import { render } from "@testing-library/vue";
+import { describe, expect, test } from "vitest";
+import { mockMapSettings, mockPinia } from "../mocks/mockPinia";
+import AdminLevelToggle from "../../../src/components/AdminLevelToggle.vue";
+import { mockVuetify } from "../mocks/mockVuetify";
+
+const renderComponent = (adminLevel: number, missingAdmin2Data = false) => {
+    const store = mockPinia({
+        mapSettings: mockMapSettings({ country: "TZA", adminLevel }),
+        appConfig: {
+            countriesWithoutAdmin2: missingAdmin2Data ? ["TZA"] : []
+        } as any
+    });
+    return render(AdminLevelToggle, {
+        global: {
+            plugins: [store, mockVuetify]
+        }
+    });
+};
+
+describe("AdminLevelToggle", () => {
+    test("renders as expected with admin level 1", async () => {
+        const { findAllByRole } = renderComponent(1);
+        const buttons = await findAllByRole("button");
+        expect(buttons.length).toBe(2);
+        const [ admin1Button, ] = buttons;
+        expect(admin1Button).toHaveClass("selected-button");
+    });
+
+    test("renders as expected with admin level 2", async () => {
+        const { findAllByRole } = renderComponent(2);
+        const buttons = await findAllByRole("button");
+        const [, admin2Button ] = buttons;
+        expect(admin2Button).toHaveClass("selected-button");
+    });
+
+    test("admin level 2 is disabled if country missing admin 2 data", async () => {
+        const { findAllByRole } = renderComponent(2, true);
+        const buttons = await findAllByRole("button");
+        const [, admin2Button ] = buttons;
+        expect(admin2Button).toBeDisabled();
+    });
+
+    test("emits when button is changed", async () => {
+        const { findAllByRole, emitted } = renderComponent(2, true);
+        const buttons = await findAllByRole("button");
+        const [ admin1Button ] = buttons;
+        admin1Button.click();
+        expect(emitted()).toHaveProperty("change-admin-level", [[1]]);
+    });
+});

--- a/tests/unit/components/adminLevelToggle.spec.ts
+++ b/tests/unit/components/adminLevelToggle.spec.ts
@@ -23,28 +23,28 @@ describe("AdminLevelToggle", () => {
         const { findAllByRole } = renderComponent(1);
         const buttons = await findAllByRole("button");
         expect(buttons.length).toBe(2);
-        const [ admin1Button, ] = buttons;
+        const [admin1Button] = buttons;
         expect(admin1Button).toHaveClass("selected-button");
     });
 
     test("renders as expected with admin level 2", async () => {
         const { findAllByRole } = renderComponent(2);
         const buttons = await findAllByRole("button");
-        const [, admin2Button ] = buttons;
+        const [, admin2Button] = buttons;
         expect(admin2Button).toHaveClass("selected-button");
     });
 
     test("admin level 2 is disabled if country missing admin 2 data", async () => {
         const { findAllByRole } = renderComponent(2, true);
         const buttons = await findAllByRole("button");
-        const [, admin2Button ] = buttons;
+        const [, admin2Button] = buttons;
         expect(admin2Button).toBeDisabled();
     });
 
     test("emits when button is changed", async () => {
         const { findAllByRole, emitted } = renderComponent(2, true);
         const buttons = await findAllByRole("button");
-        const [ admin1Button ] = buttons;
+        const [admin1Button] = buttons;
         admin1Button.click();
         expect(emitted()).toHaveProperty("change-admin-level", [[1]]);
     });

--- a/tests/unit/components/resetMapButton.spec.ts
+++ b/tests/unit/components/resetMapButton.spec.ts
@@ -3,7 +3,6 @@ import ResetMapButton from "@/components/ResetMapButton.vue";
 import { APP_BASE_ROUTE } from "../../../src/router/utils";
 import { mockRouter } from "../mocks/mockRouter";
 import { mockMapSettings, mockPinia } from "../mocks/mockPinia";
-import { flushPromises } from "@vue/test-utils";
 
 const router = mockRouter();
 

--- a/tests/unit/components/resetMapButton.spec.ts
+++ b/tests/unit/components/resetMapButton.spec.ts
@@ -3,6 +3,7 @@ import ResetMapButton from "@/components/ResetMapButton.vue";
 import { APP_BASE_ROUTE } from "../../../src/router/utils";
 import { mockRouter } from "../mocks/mockRouter";
 import { mockMapSettings, mockPinia } from "../mocks/mockPinia";
+import { flushPromises } from "@vue/test-utils";
 
 const router = mockRouter();
 
@@ -24,12 +25,15 @@ describe("ResetMapButton", () => {
         });
 
         it("should navigate to the home path when the reset button is clicked", async () => {
+            vi.useFakeTimers();
             const spyRouterPush = vi.spyOn(router, "push");
             const { getByTitle, emitted } = renderComponent();
             const resetButton = getByTitle("Reset map");
             await fireEvent.click(resetButton);
+            vi.runAllTimers();
             expect(spyRouterPush).toHaveBeenCalledWith(`/${APP_BASE_ROUTE}/indicator`);
             expect(emitted()).not.toHaveProperty("resetView");
+            vi.useRealTimers();
         });
     });
 

--- a/tests/unit/pages/index.spec.ts
+++ b/tests/unit/pages/index.spec.ts
@@ -8,7 +8,13 @@ import { mockMapSettings, mockPinia } from "../mocks/mockPinia";
 import { useAppStore } from "../../../src/stores/appStore";
 import { PATHOGEN, VERSION } from "../../../src/router/utils";
 
-const renderPage = async (indicator?: string, country: string = "", pathogen = "dengue", version = "may24", adminLevel = "") => {
+const renderPage = async (
+    indicator?: string,
+    country: string = "",
+    pathogen = "dengue",
+    version = "may24",
+    adminLevel = ""
+) => {
     await render(Index, {
         props: { pathogen, version, indicator, country, adminLevel },
         global: {

--- a/tests/unit/pages/index.spec.ts
+++ b/tests/unit/pages/index.spec.ts
@@ -8,9 +8,9 @@ import { mockMapSettings, mockPinia } from "../mocks/mockPinia";
 import { useAppStore } from "../../../src/stores/appStore";
 import { PATHOGEN, VERSION } from "../../../src/router/utils";
 
-const renderPage = async (indicator?: string, country: string = "", pathogen = "dengue", version = "may24") => {
+const renderPage = async (indicator?: string, country: string = "", pathogen = "dengue", version = "may24", adminLevel = "") => {
     await render(Index, {
-        props: { pathogen, version, indicator, country },
+        props: { pathogen, version, indicator, country, adminLevel },
         global: {
             plugins: [mockVuetify, mockPinia(), router],
             stubs: {
@@ -46,7 +46,7 @@ describe("Index page", () => {
     });
 
     test("selects country from props", async () => {
-        await renderPage("serop9", "TZA");
+        await renderPage("serop9", "TZA", "dengue", "may24", "admin2");
         const { updateMapSettings } = useAppStore();
         vi.runAllTimers();
         expect(updateMapSettings).toHaveBeenCalledWith(


### PR DESCRIPTION
This adds the admin level toggle to the map, which will only appear when you have selected a country.

Main changes:
* new `routerPush` utility with consistent debounce timeout
* new `AdminLevelToggle` component

Need to still do tests