### PR TITLE
Make leaflet attribution responsive

### DIFF
--- a/src/styles/settings.scss
+++ b/src/styles/settings.scss
@@ -49,3 +49,8 @@
   }
 }
 
+@media (max-width: 455px) {
+  .leaflet-control-attribution {
+    font-size: 0.61rem;
+  }
+}


### PR DESCRIPTION
Just a little thing I noticed on small screens. With iPhone SE, the leaflet attribution takes up two lines of real estate. Here we change the font-size so it's only one line on smaller screens.

![Screenshot from 2024-05-09 14-47-11](https://github.com/mrc-ide/arbomap/assets/60350599/fb3cd95e-8b50-4fc0-acf5-a79c9d8639ff)
![Screenshot from 2024-05-09 14-52-09](https://github.com/mrc-ide/arbomap/assets/60350599/158e5588-d01f-404b-bd0f-960199af4d3a)
