### PR TITLE
mrc-5214 User instructions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dengue-map",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "type": "module",
   "engines": {
     "node": "^20.0.0"

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -10,6 +10,7 @@ declare module 'vue' {
     AdminLevelToggle: typeof import('./components/AdminLevelToggle.vue')['default']
     Choropleth: typeof import('./components/Choropleth.vue')['default']
     ColorScaleIcon: typeof import('./components/indicatorMenu/ColorScaleIcon.vue')['default']
+    HelpAlert: typeof import('./components/HelpAlert.vue')['default']
     IndicatorMenu: typeof import('./components/indicatorMenu/IndicatorMenu.vue')['default']
     IndicatorSlideGroupItem: typeof import('./components/indicatorMenu/IndicatorSlideGroupItem.vue')['default']
     Legend: typeof import('./components/Legend.vue')['default']

--- a/src/components/AdminLevelToggle.vue
+++ b/src/components/AdminLevelToggle.vue
@@ -28,6 +28,6 @@ const emit = defineEmits(["change-admin-level"]);
     font-weight: bolder;
 }
 #admin-toggle {
-    text-align: right; /* For compatibility with HelpAlert on small screens */
+    align-self: flex-end; /* For compatibility with HelpAlert */
 }
 </style>

--- a/src/components/AdminLevelToggle.vue
+++ b/src/components/AdminLevelToggle.vue
@@ -27,4 +27,7 @@ const emit = defineEmits(["change-admin-level"]);
 .selected-button {
     font-weight: bolder;
 }
+#admin-toggle {
+    text-align: right; /* For compatibility with HelpAlert on small screens */
+}
 </style>

--- a/src/components/Choropleth.vue
+++ b/src/components/Choropleth.vue
@@ -17,9 +17,7 @@
             </LControl>
             <LControl position="topright">
                 <AdminLevelToggle @change-admin-level="handleChangeAdminLevel" v-if="mapSettings.country" />
-                <div class="float-right">
-                    <HelpAlert />
-                </div>
+                <HelpAlert />
             </LControl>
         </LMap>
         <div style="visibility: hidden" class="choropleth-data-summary" v-bind="dataSummary"></div>
@@ -118,3 +116,16 @@ const finishUpdatingMap = () => {
 
 watch(mapSettings, updateMap);
 </script>
+<style>
+.leaflet-top.leaflet-right .leaflet-control {
+    display: flex;
+    column-gap: 8px;
+    /* margin-left must belong here rather than HelpAlert, or HelpAlert's margin prevents clicks on zoom controls */
+    margin-left: 55px;
+
+    @media screen and (max-width: 768px) {
+        flex-direction: column;
+        row-gap: 8px;
+    }
+}
+</style>

--- a/src/components/Choropleth.vue
+++ b/src/components/Choropleth.vue
@@ -119,13 +119,9 @@ watch(mapSettings, updateMap);
 <style>
 .leaflet-top.leaflet-right .leaflet-control {
     display: flex;
-    column-gap: 8px;
+    flex-direction: column;
+    row-gap: 8px;
     /* margin-left must belong here rather than HelpAlert, or HelpAlert's margin prevents clicks on zoom controls */
     margin-left: 55px;
-
-    @media screen and (max-width: 768px) {
-        flex-direction: column;
-        row-gap: 8px;
-    }
 }
 </style>

--- a/src/components/Choropleth.vue
+++ b/src/components/Choropleth.vue
@@ -15,8 +15,11 @@
             <LControl position="topleft">
                 <ResetMapButton :selected-indicator="mapSettings.indicator" @reset-view="updateRegionBounds" />
             </LControl>
-            <LControl position="topright" v-if="mapSettings.country">
-                <AdminLevelToggle @change-admin-level="handleChangeAdminLevel" />
+            <LControl position="topright">
+                <AdminLevelToggle @change-admin-level="handleChangeAdminLevel" v-if="mapSettings.country" />
+                <div class="float-right">
+                    <HelpAlert />
+                </div>
             </LControl>
         </LMap>
         <div style="visibility: hidden" class="choropleth-data-summary" v-bind="dataSummary"></div>

--- a/src/components/HelpAlert.vue
+++ b/src/components/HelpAlert.vue
@@ -25,6 +25,7 @@ const helpText = `
     and at the top left to control the zoom level. To toggle admin level when viewing a selected country,
     use the controls in the top right.
 `;
+
 // Initialize alert as open or closed based on localStorage
 const isActive = ref(localStorage.getItem("helpAlertHasBeenDismissed") !== "true");
 

--- a/src/components/HelpAlert.vue
+++ b/src/components/HelpAlert.vue
@@ -1,8 +1,4 @@
 <template>
-    <v-btn id="helpButton" aria-label="Help" icon density="compact" v-show="!isActive" @click="isActive = true">
-        <v-icon>mdi-help-circle-outline</v-icon>
-        <v-tooltip location="bottom" activator="parent">Help</v-tooltip>
-    </v-btn>
     <v-alert
         v-model="isActive"
         class="elevation-1"
@@ -10,8 +6,11 @@
         closable
         title="How to use this map"
         :text="helpText"
-    >
-    </v-alert>
+    />
+    <v-btn id="helpButton" aria-label="Help" icon density="compact" v-show="!isActive" @click="isActive = !isActive">
+        <v-icon>mdi-help-circle-outline</v-icon>
+        <v-tooltip location="bottom" activator="parent">Help</v-tooltip>
+    </v-btn>
 </template>
 
 <script setup lang="ts">
@@ -60,14 +59,8 @@ $large-screen-breakpoint: calc(
     /* Undo vuetify styling which is space-inefficient in that it gives close-button a whole grid-column */
     display: unset !important;
 
-    @media screen and (max-width: 768px) {
-        order: 2;
-    }
-
     /*
-    Centering the alert (once its max-width is setting an upper limit on its width) means that
-    when the admin level toggle alternates between being present/absent, the alert does not
-    jump around.
+    Centering the alert (once the admin level toggle allows enough room)
     */
     @media screen and (min-width: $large-screen-breakpoint) {
         position: fixed !important;
@@ -84,11 +77,6 @@ $large-screen-breakpoint: calc(
     margin-bottom: 0.5rem;
 }
 #helpButton {
-    align-self: center;
-
-    @media screen and (max-width: 768px) {
-        order: 2;
-        align-self: flex-end;
-    }
+    align-self: flex-end;
 }
 </style>

--- a/src/components/HelpAlert.vue
+++ b/src/components/HelpAlert.vue
@@ -43,14 +43,36 @@ $leaflet-touch-bar-anchor-width: 30px;
 $navbar-height: 48px;
 $admin-toggle-height: 36px;
 $admin-toggle-width: 198px;
+/*
+At time of writing, keeping constant the number of lines in the paragraph (3 at this width),
+this max-width maximizes the efficient use of space within the alert. This optimal width will
+be different if the help text is changed.
+*/
+$alert-max-width: 950px;
+$large-screen-breakpoint: calc(
+    (2*$admin-toggle-width) + $alert-max-width + $leaflet-touch-bar-anchor-width + (4*$leaflet-control-margin)
+);
 .v-alert {
-    /* Undo vuetify styling which is space-inefficient in that it gives close-button a whole grid-column */
-    display: unset !important;
     padding: $v-alert-padding;
     text-align: justify;
+    max-width: $alert-max-width;
+
+    /* Undo vuetify styling which is space-inefficient in that it gives close-button a whole grid-column */
+    display: unset !important;
 
     @media screen and (max-width: 768px) {
         order: 2;
+    }
+
+    /*
+    Centering the alert (once its max-width is setting an upper limit on its width) means that
+    when the admin level toggle alternates between being present/absent, the alert does not
+    jump around.
+    */
+    @media screen and (min-width: $large-screen-breakpoint) {
+        position: fixed !important;
+        top: $navbar-height + $leaflet-control-margin;
+        left: calc((100vw - $alert-max-width)/2);
     }
 }
 .v-alert__close {

--- a/src/components/HelpAlert.vue
+++ b/src/components/HelpAlert.vue
@@ -1,5 +1,5 @@
 <template>
-    <v-btn aria-label="Help" icon density="compact" v-show="!isActive" @click="isActive = true">
+    <v-btn id="helpButton" aria-label="Help" icon density="compact" v-show="!isActive" @click="isActive = true">
         <v-icon>mdi-help-circle-outline</v-icon>
         <v-tooltip activator="parent">Help</v-tooltip>
     </v-btn>
@@ -35,15 +35,37 @@ watch(isActive, (newValue) => {
     }
 });
 </script>
-
-<style>
+<style lang="scss">
+$v-alert-padding: 12px; // This is a little more compact than Vuetify's default (16px)
+$leaflet-control-margin: 10px;
+$leaflet-touch-bar-anchor-width: 30px;
+$navbar-height: 48px;
+$admin-toggle-height: 36px;
+$admin-toggle-width: 198px;
 .v-alert {
-    position: fixed !important;
-    top: 58px;
-    left: 55px;
-    max-width: calc(100vw - (55px + 5px));
+    /* Undo vuetify styling which is space-inefficient in that it gives close-button a whole grid-column */
+    display: unset !important;
+    padding: $v-alert-padding;
+    text-align: justify;
+
+    @media screen and (max-width: 768px) {
+        order: 2;
+    }
+}
+.v-alert__close {
+    position: absolute;
+    top: $v-alert-padding;
+    right: $v-alert-padding;
 }
 .v-alert-title {
     margin-bottom: 0.5rem;
+}
+#helpButton {
+    align-self: center;
+
+    @media screen and (max-width: 768px) {
+        order: 2;
+        align-self: flex-end;
+    }
 }
 </style>

--- a/src/components/HelpAlert.vue
+++ b/src/components/HelpAlert.vue
@@ -1,7 +1,7 @@
 <template>
     <v-btn id="helpButton" aria-label="Help" icon density="compact" v-show="!isActive" @click="isActive = true">
         <v-icon>mdi-help-circle-outline</v-icon>
-        <v-tooltip activator="parent">Help</v-tooltip>
+        <v-tooltip location="bottom" activator="parent">Help</v-tooltip>
     </v-btn>
     <v-alert
         v-model="isActive"

--- a/src/components/HelpAlert.vue
+++ b/src/components/HelpAlert.vue
@@ -50,7 +50,7 @@ be different if the help text is changed.
 */
 $alert-max-width: 950px;
 $large-screen-breakpoint: calc(
-    (2*$admin-toggle-width) + $alert-max-width + $leaflet-touch-bar-anchor-width + (4*$leaflet-control-margin)
+    (2 * $admin-toggle-width) + $alert-max-width + $leaflet-touch-bar-anchor-width + (4 * $leaflet-control-margin)
 );
 .v-alert {
     padding: $v-alert-padding;
@@ -72,7 +72,7 @@ $large-screen-breakpoint: calc(
     @media screen and (min-width: $large-screen-breakpoint) {
         position: fixed !important;
         top: $navbar-height + $leaflet-control-margin;
-        left: calc((100vw - $alert-max-width)/2);
+        left: calc((100vw - $alert-max-width) / 2);
     }
 }
 .v-alert__close {

--- a/src/components/HelpAlert.vue
+++ b/src/components/HelpAlert.vue
@@ -1,0 +1,49 @@
+<template>
+    <v-btn aria-label="Help" icon density="compact" v-show="!isActive" @click="isActive = true">
+        <v-icon>mdi-help-circle-outline</v-icon>
+        <v-tooltip activator="parent">Help</v-tooltip>
+    </v-btn>
+    <v-alert
+        v-model="isActive"
+        class="elevation-1"
+        color="blue-lighten-5"
+        closable
+        title="How to use this map"
+        :text="helpText"
+    >
+    </v-alert>
+</template>
+
+<script setup lang="ts">
+import { ref, watch } from "vue";
+
+const helpText = `
+    DengueMap provides high-resolution estimates of dengue transmission intensity in countries where
+    dengue is endemic. View estimated values for a region by hovering your cursor over it on the map.
+    Click on a region to view that country's values at higher resolution. Click on the selected
+    country again to return to default view. Use buttons at the bottom left to select estimate indicator,
+    and at the top left to control the zoom level. To toggle admin level when viewing a selected country,
+    use the controls in the top right.
+`;
+// Initialize alert as open or closed based on localStorage
+const isActive = ref(localStorage.getItem("helpAlertHasBeenDismissed") !== "true");
+
+// Update localStorage when alert is dismissed
+watch(isActive, (newValue) => {
+    if (newValue === false) {
+        localStorage.setItem("helpAlertHasBeenDismissed", "true");
+    }
+});
+</script>
+
+<style>
+.v-alert {
+    position: fixed !important;
+    top: 58px;
+    left: 55px;
+    max-width: calc(100vw - (55px + 5px));
+}
+.v-alert-title {
+    margin-bottom: 0.5rem;
+}
+</style>

--- a/src/components/ResetMapButton.vue
+++ b/src/components/ResetMapButton.vue
@@ -16,7 +16,6 @@
 <script setup lang="ts">
 import { storeToRefs } from "pinia";
 import { useRouter } from "vue-router";
-import { defineProps, defineEmits } from "vue";
 import { APP_BASE_ROUTE } from "../router/utils";
 import { useAppStore } from "../stores/appStore";
 import { routerPush } from "../utils";

--- a/tests/e2e/index.spec.ts
+++ b/tests/e2e/index.spec.ts
@@ -17,7 +17,7 @@ test.describe("Index page", () => {
     });
 
     test("can see app title", async ({ page }) => {
-        await expect(await page.getByText("DengueMap")).toBeVisible();
+        await expect(await page.locator(".v-app-bar-title:has-text('DengueMap')")).toBeVisible();
     });
 
     test("loading spinner is shown on page load", async ({ page }) => {

--- a/tests/e2e/index.spec.ts
+++ b/tests/e2e/index.spec.ts
@@ -205,4 +205,12 @@ test.describe("Index page", () => {
 
         await expect(await admin1Outlines).toHaveCount(18);
     });
+
+    test("help alert is shown, can be dismissed, and stays dismissed after reloading map", async ({ page }) => {
+        await expect(await page.getByText("How to use this map")).toBeVisible();
+        await page.getByRole("button", { name: "Close" }).click();
+        await expect(await page.getByText("How to use this map")).not.toBeVisible();
+        await page.goto("/dengue/may24/FOI/AGO/admin1");
+        await expect(await page.getByText("How to use this map")).not.toBeVisible();
+    });
 });

--- a/tests/unit/components/choropleth.spec.ts
+++ b/tests/unit/components/choropleth.spec.ts
@@ -16,7 +16,7 @@ describe("Choropleth", () => {
     test("renders as expected", async () => {
         const comp = renderComponent();
         const map = (comp.baseElement as any).children[0].children[0].children[0];
-        expect(map.children.length).toBe(3);
+        expect(map.children.length).toBe(4);
         const tileLayer = map.children[0];
         expect(tileLayer.tagName).toBe("L-TILE-LAYER-STUB");
         expect(tileLayer.getAttribute("maxzoom")).toBe("10");

--- a/tests/unit/components/helpAlert.spec.ts
+++ b/tests/unit/components/helpAlert.spec.ts
@@ -1,0 +1,52 @@
+import { render, screen, fireEvent } from "@testing-library/vue";
+import HelpAlert from "@/components/HelpAlert.vue";
+import { mockVuetify } from "../mocks/mockVuetify";
+
+const vuetify = mockVuetify;
+const renderComponent = () => {
+    return render(HelpAlert, {
+        global: { plugins: [vuetify] }
+    });
+};
+
+describe("HelpAlert", () => {
+    describe("When the alert has not been dismissed before", () => {
+        it("should show the alert", () => {
+            renderComponent();
+            expect(screen.getByRole("alert")).toBeVisible();
+        });
+    });
+
+    describe("When the alert was dismissed in the past", () => {
+        let originalLocalStorage;
+
+        beforeAll((): void => {
+            const localStorageMock = (() => {
+                return {
+                    getItem: vi.fn(() => "true"),
+                    setItem: vi.fn()
+                };
+            })();
+
+            originalLocalStorage = window.localStorage;
+            (window as any).localStorage = localStorageMock;
+        });
+
+        afterAll((): void => {
+            (window as any).localStorage = originalLocalStorage;
+        });
+
+        it("should not show the alert", () => {
+            renderComponent();
+            expect(screen.queryByRole("alert")).toBeNull();
+        });
+
+        it("can show the alert when the help button is clicked", async () => {
+            renderComponent();
+            expect(screen.queryByRole("alert")).toBeNull();
+            const helpButton = screen.getByRole("button");
+            await fireEvent.click(helpButton);
+            expect(screen.getByRole("alert")).toBeVisible();
+        });
+    });
+});


### PR DESCRIPTION
These instructions should be visible at first, and then if the user ever dismisses them, they have to click the right button to get the help text back. This preference will be persisted between sessions in localStorage. (You can evade that by using a private browsing window such as incognito, allowing you to test it.)

I wonder if this merits an e2e test on top of the component test? To verify that the alert is present on the first visit, and stays dismissed once dismissed when you navigate to a new page.

Rebased onto the admin level toggle branch because this is using the same top-right corner of the map as that branch.