### PR TITLE
mrc-5350 Show app version

### DIFF
--- a/.github/workflows/deploy-to-ghp.yml
+++ b/.github/workflows/deploy-to-ghp.yml
@@ -4,7 +4,7 @@ name: Deploy static content to Pages
 on:
   # Runs on pushes targeting the default branch
   push:
-    branches: ['main', 'mrc-5207']
+    branches: ['main', 'mrc-5350']
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,5 +20,7 @@ jobs:
           cache: 'npm'
       - name: Install dependencies
         run: npm ci
+      - name: Prebuild (generate version)
+        run: npm run prebuild
       - name: Lint
         run: npm run lint  

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,8 @@ jobs:
           cache: 'npm'
       - name: Install dependencies
         run: npm ci
+      - name: Prebuild (generate version)
+        run: npm run prebuild
       - name: Test
         run: npm run test:coverage
       - name: Upload coverage to codecov

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ data/processed
 /playwright-report/
 /blob-report/
 /playwright/.cache/
+src/version.ts

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "scripts": {
     "dev": "npm run prebuild && vite",
-    "prebuild": "node scripts/npm/prebuild.cjs $(git rev-parse HEAD)",
+    "prebuild": "node scripts/npm/prebuild.cjs $(git rev-parse --short HEAD) $(git symbolic-ref --short HEAD)",
     "build": "npm run prebuild && vue-tsc --noEmit && vite build",
     "preview": "vite preview",
     "lint-fix": "eslint . --fix --ignore-path .gitignore",

--- a/package.json
+++ b/package.json
@@ -1,13 +1,14 @@
 {
   "name": "dengue-map",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "type": "module",
   "engines": {
     "node": "^20.0.0"
   },
   "scripts": {
-    "dev": "vite",
-    "build": "vue-tsc --noEmit && vite build",
+    "dev": "npm run prebuild && vite",
+    "prebuild": "node scripts/npm/prebuild.cjs $(git rev-parse HEAD)",
+    "build": "npm run prebuild && vue-tsc --noEmit && vite build",
     "preview": "vite preview",
     "lint-fix": "eslint . --fix --ignore-path .gitignore",
     "lint": "eslint . --ignore-path .gitignore",

--- a/scripts/npm/prebuild.cjs
+++ b/scripts/npm/prebuild.cjs
@@ -1,18 +1,18 @@
 // Include git commit and branch in command line args
 const gitCommit = process.argv[2];
 const gitBranch = process.argv[3];
+
 const path = require("path");
 const fs = require("fs");
-const baseLocation = `${__dirname}/../..`;
-const packageVersion = require(`${baseLocation}/package.json`).version;
 
-const output =
-`export const PACKAGE_VERSION="${packageVersion}";
+const packageVersion = require("../../package.json").version;
+
+const output = `export const PACKAGE_VERSION="${packageVersion}";
 export const GIT_COMMIT="${gitCommit}";
 export const GIT_BRANCH="${gitBranch}";
 `;
 
-const outputLocation = path.normalize(`${baseLocation}/src/version.ts`);
+const outputLocation = path.normalize(`${__dirname}/../../src/version.ts`);
 fs.writeFile(outputLocation, output, (err) => {
     if (err) {
         throw err;

--- a/scripts/npm/prebuild.cjs
+++ b/scripts/npm/prebuild.cjs
@@ -1,0 +1,14 @@
+// Include git sha in command line arg
+const gitSha = process.argv[2];
+const path = require("path");
+const fs = require("fs");
+const baseLocation = `${__dirname}/../..`;
+const packageVersion = require(`${baseLocation}/package.json`).version;
+
+const output = `export const PACKAGE_VERSION="${packageVersion}";\nexport const GIT_SHA="${gitSha}";`;
+const outputLocation = path.normalize(`${baseLocation}/src/version.ts`);
+fs.writeFile(outputLocation, output, (err) => {
+    if (err) {
+        throw err;
+    }
+});

--- a/scripts/npm/prebuild.cjs
+++ b/scripts/npm/prebuild.cjs
@@ -1,11 +1,17 @@
-// Include git sha in command line arg
-const gitSha = process.argv[2];
+// Include git commit and branch in command line args
+const gitCommit = process.argv[2];
+const gitBranch = process.argv[3];
 const path = require("path");
 const fs = require("fs");
 const baseLocation = `${__dirname}/../..`;
 const packageVersion = require(`${baseLocation}/package.json`).version;
 
-const output = `export const PACKAGE_VERSION="${packageVersion}";\nexport const GIT_SHA="${gitSha}";`;
+const output =
+`export const PACKAGE_VERSION="${packageVersion}";
+export const GIT_COMMIT="${gitCommit}";
+export const GIT_BRANCH="${gitBranch}";
+`;
+
 const outputLocation = path.normalize(`${baseLocation}/src/version.ts`);
 fs.writeFile(outputLocation, output, (err) => {
     if (err) {

--- a/src/pages/about.vue
+++ b/src/pages/about.vue
@@ -33,26 +33,29 @@
                 </p>
                 <p>
                     You are viewing {{ appConfig?.title }} version {{ PACKAGE_VERSION }}.
-                    <v-btn variant="plain"
-                           size="small"
-                           :ripple="false"
-                           class=""
-                           @click="showVersionDetails=!showVersionDetails;"
+                    <v-btn
+                        variant="plain"
+                        size="small"
+                        :ripple="false"
+                        class=""
+                        @click="showVersionDetails = !showVersionDetails"
                     >
                         {{ showVersionDetails ? "Hide" : "Show" }} details
                     </v-btn>
-                    <div v-if="showVersionDetails">
-                        Git branch: {{ GIT_BRANCH }} | Git commit: {{ GIT_COMMIT }}
-                    </div>
                 </p>
+            </v-row>
+            <v-row>
+                <div v-if="showVersionDetails" class="text-body-1">
+                    Git branch: {{ GIT_BRANCH }} | Git commit: {{ GIT_COMMIT }}
+                </div>
+            </v-row>
+            <v-row>
                 <p class="text-body-1 font-italic">
                     [1] L. Cattarino, I. Rodriguez-Barraquer, N. Imai, D. A. T. Cummings, and N. M. Ferguson, “Mapping
                     global variation in dengue transmission intensity,” Sci. Transl. Med., vol. 12, no. 528, Jan. 2020.
                 </p>
             </v-row>
-            <v-row>
-
-            </v-row>
+            <v-row> </v-row>
             <v-row class="justify-center mt-12">
                 <v-img
                     alt="Logo of the Drugs for Neglected Diseases initiative (DNDi)"
@@ -85,9 +88,9 @@
     </v-container>
 </template>
 <script setup>
-import {GIT_BRANCH, GIT_COMMIT, PACKAGE_VERSION} from "../version";
-import {storeToRefs} from "pinia";
-import {useAppStore} from "../stores/appStore";
+import { storeToRefs } from "pinia";
+import { GIT_BRANCH, GIT_COMMIT, PACKAGE_VERSION } from "../version";
+import { useAppStore } from "../stores/appStore";
 
 const { appConfig } = storeToRefs(useAppStore());
 

--- a/src/pages/about.vue
+++ b/src/pages/about.vue
@@ -31,10 +31,27 @@
                     was co-funded by the World Health Organization and developed in collaboration with the Drugs for
                     Neglected Diseases initiative.
                 </p>
+                <p>
+                    You are viewing {{ appConfig?.title }} version {{ PACKAGE_VERSION }}.
+                    <v-btn variant="plain"
+                           size="small"
+                           :ripple="false"
+                           class=""
+                           @click="showVersionDetails=!showVersionDetails;"
+                    >
+                        {{ showVersionDetails ? "Hide" : "Show" }} details
+                    </v-btn>
+                    <div v-if="showVersionDetails">
+                        Git branch: {{ GIT_BRANCH }} | Git commit: {{ GIT_COMMIT }}
+                    </div>
+                </p>
                 <p class="text-body-1 font-italic">
                     [1] L. Cattarino, I. Rodriguez-Barraquer, N. Imai, D. A. T. Cummings, and N. M. Ferguson, “Mapping
                     global variation in dengue transmission intensity,” Sci. Transl. Med., vol. 12, no. 528, Jan. 2020.
                 </p>
+            </v-row>
+            <v-row>
+
             </v-row>
             <v-row class="justify-center mt-12">
                 <v-img
@@ -67,3 +84,12 @@
         </v-col>
     </v-container>
 </template>
+<script setup>
+import {GIT_BRANCH, GIT_COMMIT, PACKAGE_VERSION} from "../version";
+import {storeToRefs} from "pinia";
+import {useAppStore} from "../stores/appStore";
+
+const { appConfig } = storeToRefs(useAppStore());
+
+const showVersionDetails = ref(false);
+</script>

--- a/tests/unit/pages/about.spec.ts
+++ b/tests/unit/pages/about.spec.ts
@@ -1,0 +1,42 @@
+import { render, screen } from "@testing-library/vue";
+import { userEvent } from "@testing-library/user-event";
+import { describe, expect, test } from "vitest";
+import About from "../../../src/pages/about.vue";
+import { mockPinia } from "../mocks/mockPinia";
+import { mockVuetify } from "../mocks/mockVuetify";
+import { GIT_BRANCH, GIT_COMMIT, PACKAGE_VERSION } from "../../../src/version";
+
+const renderPage = async () => {
+    await render(About, {
+        global: {
+            plugins: [mockVuetify, mockPinia()]
+        }
+    });
+};
+
+describe("About page", () => {
+    test("displays package version", async () => {
+        await renderPage();
+        const versionPara = await screen.findByText(`You are viewing MockApp version ${PACKAGE_VERSION}`, {
+            exact: false
+        });
+        expect(versionPara).toBeVisible();
+        expect(await screen.queryByText(/Git branch/)).toBe(null);
+    });
+
+    test("displays and hides version details when button clicked", async () => {
+        await renderPage();
+        const detailsButton = await screen.findByText("Show details");
+        const user = userEvent.setup();
+
+        await user.click(detailsButton);
+        const detailsText = `Git branch: ${GIT_BRANCH} | Git commit: ${GIT_COMMIT}`;
+        expect(await screen.findByText("Hide details")).toBeVisible();
+        expect(await screen.queryByText("Show details")).toBe(null);
+
+        await user.click(detailsButton);
+        expect(await screen.queryByText(detailsText)).toBe(null);
+        expect(await screen.findByText("Show details")).toBeVisible();
+        expect(await screen.queryByText("Hide details")).toBe(null);
+    });
+});


### PR DESCRIPTION
This branch adds some version visibility into the app. 

At the bottom of the text of the About page (but above the footnote), it shows the version from package.json, with a text button to click to show/hide details - these details are the Git branch and short commit, so of no interest to most users. 

There is a new "prebuild" npm step which gets the git details and package version, and writes these out to `src/version.ts` (which is gitignored), where they are available to the page. This step is run as the first part of `build` and `dev`.

This approach will rely on us remembering to update the package version regularly (minor version for new feature, patch for bug fix) - I'd prefer to avoid the annoyance of the NEWS descriptions that we had in HINT - but with the fallback of being able to check git details if need be. 