### PR TITLE
mrc-5199 add no data tooltip

### DIFF
--- a/src/composables/useTooltips.ts
+++ b/src/composables/useTooltips.ts
@@ -26,7 +26,13 @@ export const useTooltips = (selectedIndicators: ComputedRef<FeatureIndicators>) 
 
     const tooltipForFeature = (featureId: string, featureName: string) => {
         const tooltipOptions = { sticky: true };
-        if (!(featureId in selectedIndicators.value)) return null;
+        if (!(featureId in selectedIndicators.value)) {
+            return {
+                content: `<div class="text-body-1">${featureName}</div>
+                          <div class="text-body-2 missing-data-tooltip-text">No data</div>`,
+                options: tooltipOptions
+            };
+        }
         const featureValues = selectedIndicators.value[featureId];
         let indicatorValues = "";
         sortedIndicators.value.forEach((metadata, indicatorKey) => {

--- a/src/styles/settings.scss
+++ b/src/styles/settings.scss
@@ -62,3 +62,7 @@ html {
     font-size: 0.61rem;
   }
 }
+
+.missing-data-tooltip-text {
+  color: grey
+}

--- a/tests/e2e/index.spec.ts
+++ b/tests/e2e/index.spec.ts
@@ -79,6 +79,13 @@ test.describe("Index page", () => {
         await expect(await page.innerText(".leaflet-tooltip-pane")).toContain("Hospital admissions: 126");
     });
 
+    test("if no data, no data tooltip is shown", async ({ page }) => {
+        const firstRegion = await getNthRegion(page, 30);
+        await firstRegion.hover();
+        await expect(await page.innerText(".leaflet-tooltip-pane")).toContain("Mendoza");
+        await expect(await page.innerText(".leaflet-tooltip-pane")).toContain("No data");
+    });
+
     test("selecting country fades colours of other countries", async ({ page }) => {
         const firstRegion = await getNthRegion(page, 1);
         const colour = await firstRegion.getAttribute("fill");


### PR DESCRIPTION
tooltips in areas without data such as the empty regions in australia were just empty before, now they will still display the name of the region and have no data text in grey