### PR TITLE
mrc-5398 Bug fix for direct browse to admin1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dengue-map",
-  "version": "0.2.1",
+  "version": "0.3.1",
   "type": "module",
   "engines": {
     "node": "^20.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dengue-map",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "module",
   "engines": {
     "node": "^20.0.0"

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -46,10 +46,11 @@ export const useAppStore = defineStore("app", {
 
             let level = adminLevel;
             // Some countries do not have admin2 regions or data - if one of these is selected, we load
-            // a more detailed geojson, and re-use its admin1 indicators as "admin2"
+            // a more detailed admin1 geojson, and re-use its admin1 indicators as "admin2"
             const admin2DataMissing = state.appConfig.countriesWithoutAdmin2.includes(country);
             if (level === 2) {
                 if (admin2DataMissing) {
+                    // The more detailed level (2) was requested but we actually need to load level 1 for this country
                     level = 1;
                     state.admin2Indicators[country] = state.admin1Indicators[country];
                 } else {
@@ -57,7 +58,8 @@ export const useAppStore = defineStore("app", {
                         state.admin2Indicators[country] || (await getIndicators(country, level));
                 }
 
-                state.admin2Geojson[country] = state.admin2Geojson[country] || (await getGeojsonFeatures(country, level));
+                state.admin2Geojson[country] =
+                    state.admin2Geojson[country] || (await getGeojsonFeatures(country, level));
             }
 
             state.admin0GeojsonFeature = (await getGeojsonFeatures(country, 0))[0];

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -56,9 +56,9 @@ export const useAppStore = defineStore("app", {
                     state.admin2Indicators[country] =
                         state.admin2Indicators[country] || (await getIndicators(country, level));
                 }
-            }
 
-            state.admin2Geojson[country] = state.admin2Geojson[country] || (await getGeojsonFeatures(country, level));
+                state.admin2Geojson[country] = state.admin2Geojson[country] || (await getGeojsonFeatures(country, level));
+            }
 
             state.admin0GeojsonFeature = (await getGeojsonFeatures(country, 0))[0];
             // account for the fact that some countries do not have admin level 2 data

--- a/tests/e2e/routing.spec.ts
+++ b/tests/e2e/routing.spec.ts
@@ -63,6 +63,16 @@ test.describe("Router", () => {
         await expectIndexPage(page, "/FOI/TZA", "FOI", "Force of infection", "TZA", "interpolateRdYlBu", 2070, 186);
     });
 
+    test("browse to indicator and country at admin1 loads expected data", async ({ page }) => {
+        await page.goto(`${BASE_URL}/FOI/VEN/admin1`);
+        await expect(await page.textContent(".indicator-menu-activator")).toBe("Force of infection");
+        const summary = await page.locator(".choropleth-data-summary");
+        await expect(await summary).toHaveAttribute("color-scale", "interpolateRdYlBu");
+        await expect(await summary).toHaveAttribute("selected-country-id", "VEN");
+        await expect(await summary).toHaveAttribute("feature-count", "1915");
+        await expect(await summary).toHaveAttribute("selected-country-feature-count", "25");
+    });
+
     test("is case-insensitive", async ({ page }) => {
         await page.goto("/DENGUE/May24/SEROP9/tza");
         await page.waitForURL(/\/dengue\/may24\/serop9\/TZA/);


### PR DESCRIPTION
Direct browsing to urls like `/dengue/may24/FOI/VEN/admin1` were failing because the store was wrongly attempting to load detailed (aka "admin2", misleadingly) geojson for the selected country even if the non-detailed admin1 level was selected. However it was also choosing the filename to attempt to load based on the selected level, admin1. Hence attempting to load detailed admin1 files for countries which did not have them i.e. countries which do have admin2 data (most of them). 

Moving the detailed geojson load inside the check for initial requested admin level == 2 fixes this problem. 

This code is pretty confusing and sometimes misleading - we're going to refactor it in a future ticket when we revamp the geojson loading. 

I *was* able to reproduce the bug for Brazil after I did a browser restart so maybe it wasn't showing before for us because of store being retained, but it all seems a bit of a coincidence... 🤷  