### PR TITLE
mrc-5213 Analytics

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,8 +6,15 @@
     <link rel="icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title></title>
-    <!--<script defer src="https://cloud.umami.is/script.js" data-website-id="50ca37bf-c6c0-48fb-bc48-44d5411627f9"></script>-->
     <script>
+        // load analytics script on production only
+        if (window.location.hostname === "arbomap.org") {
+            var tag = document.createElement('script');
+            tag.src = "https://cloud.umami.is/script.js";
+            tag.defer = true;
+            tag.setAttribute("data-website-id", "50ca37bf-c6c0-48fb-bc48-44d5411627f9");
+            document.head.appendChild(tag);
+        }
     </script>
 </head>
 

--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
     <link rel="icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title></title>
+    <script defer src="https://cloud.umami.is/script.js" data-website-id="50ca37bf-c6c0-48fb-bc48-44d5411627f9"></script>
 </head>
 
 <body>

--- a/index.html
+++ b/index.html
@@ -6,7 +6,9 @@
     <link rel="icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title></title>
-    <script defer src="https://cloud.umami.is/script.js" data-website-id="50ca37bf-c6c0-48fb-bc48-44d5411627f9"></script>
+    <!--<script defer src="https://cloud.umami.is/script.js" data-website-id="50ca37bf-c6c0-48fb-bc48-44d5411627f9"></script>-->
+    <script>
+    </script>
 </head>
 
 <body>


### PR DESCRIPTION
This branch adds analytics recording with [umami](https://umami.is/).
The tag to load the analytics script is only included in `index.html` if the current host is production, so no events should be recorded on localhost or the staging github pages site.

This branch is currently deployed to production for testing. 

I've added the email address and password for logging into our account on https://umami.is/ to the vault (secret name "umami") - so you should be able to log in there, then visit pages on https://arbomap.org and see the events appear on the umami dashboard (the Realtime view is easiest for that). 