### PR TITLE
mrc-5346 Redirect 403 to index page

### DIFF
--- a/public/.htaccess
+++ b/public/.htaccess
@@ -1,2 +1,3 @@
 # Reroute all unknown urls to the app for front-end routing
 ErrorDocument 404 /index.html
+ErrorDocument 403 /index.html


### PR DESCRIPTION
Previously, browse to https://arbomap.org/dengue/ or https://arbomap.org/dengue/may24 was returning 403 with default error page. 

We had already redirected all 404s to the index page, to allow the front end router to deal with all routes unknown to server - this change does the same for 403s. I'm not completely sure why some routes were returning 403 rather than 404 - I think it's because those routes do actually correspond to subfolders of `public` on disk, but we haven't configured directory listing. 

I've uploaded the modified .htaccess to the server, and those routes should now be working. 